### PR TITLE
Runtime stability timeout for main/backup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ endforeach()
 # SRT_DEBUG_TSBPD_WRAP 1          /* Debug packet timestamp wraparound */
 # SRT_DEBUG_TLPKTDROP_DROPSEQ 1
 # SRT_DEBUG_SNDQ_HIGHRATE 1
+# SRT_DEBUG_BONDING_STATES 1
 # SRT_MAVG_SAMPLING_RATE 40       /* Max sampling rate */
 
 # option defaults

--- a/docs/APISocketOptions.md
+++ b/docs/APISocketOptions.md
@@ -427,6 +427,8 @@ function will return the group, not this socket ID.
 | --------------------- | ----- | ------- | ---------- | ------ | -------- | ------ | --- | ------ |
 | `SRTO_GROUPSTABTIMEO` | 1.5.0 | pre     | `int32_t`  | ms     | 80       | 10-... | W   | GSD+   |
 
+**Not in use at the moment. Is to be repurposed in SRT v1.4.3!**
+
 This setting is used for groups of type `SRT_GTYPE_BACKUP`. It defines the stability
 timeout, which is the maximum interval between two consecutive packets retrieved from
 the peer on the currently active link. These two packets can be of any type,

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -11172,7 +11172,7 @@ bool CUDT::checkExpTimer(const steady_clock::time_point& currtime, int check_rea
      * (keepalive fix)
      * duB:
      * It seems there is confusion of the direction of the Response here.
-     * LastRspTime is supposed to be when receiving (data/ctrl) from peer
+     * lastRspTime is supposed to be when receiving (data/ctrl) from peer
      * as shown in processCtrl and processData,
      * Here we set because we sent something?
      *

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -374,9 +374,12 @@ public: // internal API
 
     bool isOPT_TsbPd() const { return m_bOPT_TsbPd; }
     int RTT() const { return m_iRTT; }
+    int RTTVar() const { return m_iRTTVar; }
     int32_t sndSeqNo() const { return m_iSndCurrSeqNo; }
     int32_t schedSeqNo() const { return m_iSndNextSeqNo; }
     bool overrideSndSeqNo(int32_t seq);
+    srt::sync::steady_clock::time_point LastRspTime() const { return m_tsLastRspTime; }
+    srt::sync::steady_clock::time_point ActivatedSince() const { return m_tsActivationSince; }
 
     int32_t rcvSeqNo() const { return m_iRcvCurrSeqNo; }
     int flowWindowSize() const { return m_iFlowWindowSize; }
@@ -386,6 +389,7 @@ public: // internal API
     int MSS() const { return m_iMSS; }
 
     uint32_t latency_us() const {return m_iTsbPdDelay_ms*1000; }
+    int peer_idle_tout_ms() const { return m_iOPT_PeerIdleTimeout; }
     size_t maxPayloadSize() const { return m_iMaxSRTPayloadSize; }
     size_t OPT_PayloadSize() const { return m_zOPT_ExpPayloadSize; }
     int sndLossLength() { return m_pSndLossList->getLossLength(); }

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -378,8 +378,8 @@ public: // internal API
     int32_t sndSeqNo() const { return m_iSndCurrSeqNo; }
     int32_t schedSeqNo() const { return m_iSndNextSeqNo; }
     bool overrideSndSeqNo(int32_t seq);
-    srt::sync::steady_clock::time_point LastRspTime() const { return m_tsLastRspTime; }
-    srt::sync::steady_clock::time_point FreshActivationStart() const { return m_tsFreshActivation; }
+    srt::sync::steady_clock::time_point lastRspTime() const { return m_tsLastRspTime; }
+    srt::sync::steady_clock::time_point freshActivationStart() const { return m_tsFreshActivation; }
 
     int32_t rcvSeqNo() const { return m_iRcvCurrSeqNo; }
     int flowWindowSize() const { return m_iFlowWindowSize; }
@@ -388,8 +388,8 @@ public: // internal API
     int64_t maxBandwidth() const { return m_llMaxBW; }
     int MSS() const { return m_iMSS; }
 
-    uint32_t peer_latency_us() const {return m_iPeerTsbPdDelay_ms * 1000; }
-    int peer_idle_tout_ms() const { return m_iOPT_PeerIdleTimeout; }
+    uint32_t peerLatency_us() const {return m_iPeerTsbPdDelay_ms * 1000; }
+    int peerIdleTimeout_ms() const { return m_iOPT_PeerIdleTimeout; }
     size_t maxPayloadSize() const { return m_iMaxSRTPayloadSize; }
     size_t OPT_PayloadSize() const { return m_zOPT_ExpPayloadSize; }
     int sndLossLength() { return m_pSndLossList->getLossLength(); }

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -388,7 +388,7 @@ public: // internal API
     int64_t maxBandwidth() const { return m_llMaxBW; }
     int MSS() const { return m_iMSS; }
 
-    uint32_t latency_us() const {return m_iTsbPdDelay_ms*1000; }
+    uint32_t peer_latency_us() const {return m_iPeerTsbPdDelay_ms * 1000; }
     int peer_idle_tout_ms() const { return m_iOPT_PeerIdleTimeout; }
     size_t maxPayloadSize() const { return m_iMaxSRTPayloadSize; }
     size_t OPT_PayloadSize() const { return m_zOPT_ExpPayloadSize; }

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -379,7 +379,7 @@ public: // internal API
     int32_t schedSeqNo() const { return m_iSndNextSeqNo; }
     bool overrideSndSeqNo(int32_t seq);
     srt::sync::steady_clock::time_point LastRspTime() const { return m_tsLastRspTime; }
-    srt::sync::steady_clock::time_point ActivatedSince() const { return m_tsActivationSince; }
+    srt::sync::steady_clock::time_point FreshActivationStart() const { return m_tsFreshActivation; }
 
     int32_t rcvSeqNo() const { return m_iRcvCurrSeqNo; }
     int flowWindowSize() const { return m_iFlowWindowSize; }


### PR DESCRIPTION
### TODO

- [x] `CUDTGroup::sendBackup_CheckParallelLinks` should be split into two functions: one that activates a backup link, another that silences one of the parallel links.