### PR TITLE
Fix solaris unit tests

### DIFF
--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -265,15 +265,57 @@ void srt::CChannel::attach(UDPSOCKET udpsock, const sockaddr_any& udpsocks_addr)
 
 void srt::CChannel::setUDPSockOpt()
 {
-#if defined(BSD) || TARGET_OS_MAC
-    // BSD system will fail setsockopt if the requested buffer size exceeds system maximum value
+   // Retrieve starting SND/RCV Buffer sizes.
+   socklen_t optSize;
+   int startRCVBUF = 0;
+   optSize = sizeof(startRCVBUF);
+   if (0 != ::getsockopt(
+               m_iSocket, SOL_SOCKET, SO_RCVBUF, (void*)&startRCVBUF, &optSize))
+   {
+      startRCVBUF = -1;
+   }
+   int startSNDBUF = 0;
+   optSize = sizeof(startSNDBUF);
+   if (0 != ::getsockopt(
+               m_iSocket, SOL_SOCKET, SO_SNDBUF, (void*)&startSNDBUF, &optSize))
+   {
+      startSNDBUF = -1;
+   }
+
+#if defined(BSD) || TARGET_OS_MAC || defined(SUNOS)
+    // BSD and SunOS systems, will fail setsockopt if the requested buffer size exceeds system maximum value.
+    // Also do not reduce the buffer size.
     int maxsize = 64000;
     if (0 != ::setsockopt(
                  m_iSocket, SOL_SOCKET, SO_RCVBUF, (const char*)&m_mcfg.iUDPRcvBufSize, sizeof m_mcfg.iUDPRcvBufSize))
-        ::setsockopt(m_iSocket, SOL_SOCKET, SO_RCVBUF, (const char*)&maxsize, sizeof maxsize);
+    {
+       int currentRCVBUF = 0;
+       optSize = sizeof(currentRCVBUF);
+       if (0 != ::getsockopt(
+                   m_iSocket, SOL_SOCKET, SO_RCVBUF, (void*)&currentRCVBUF, &optSize))
+       {
+          currentRCVBUF = -1;
+       }
+       if (maxsize > currentRCVBUF)
+       {
+          ::setsockopt(m_iSocket, SOL_SOCKET, SO_RCVBUF, (const char*)&maxsize, sizeof maxsize);
+       }
+    }
     if (0 != ::setsockopt(
                  m_iSocket, SOL_SOCKET, SO_SNDBUF, (const char*)&m_mcfg.iUDPSndBufSize, sizeof m_mcfg.iUDPSndBufSize))
-        ::setsockopt(m_iSocket, SOL_SOCKET, SO_SNDBUF, (const char*)&maxsize, sizeof maxsize);
+    {
+       int currentSNDBUF = 0;
+       optSize = sizeof(currentSNDBUF);
+       if (0 != ::getsockopt(
+                   m_iSocket, SOL_SOCKET, SO_RCVBUF, (void*)&currentSNDBUF, &optSize))
+       {
+          currentSNDBUF = -1;
+       }
+       if (maxsize > currentSNDBUF)
+       {
+          ::setsockopt(m_iSocket, SOL_SOCKET, SO_SNDBUF, (const char*)&maxsize, sizeof maxsize);
+       }
+    }
 #else
     // for other systems, if requested is greated than maximum, the maximum value will be automactally used
     if ((0 !=
@@ -283,6 +325,35 @@ void srt::CChannel::setUDPSockOpt()
                   m_iSocket, SOL_SOCKET, SO_SNDBUF, (const char*)&m_mcfg.iUDPSndBufSize, sizeof m_mcfg.iUDPSndBufSize)))
         throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
 #endif
+
+   // Retrieve ending SND/RCV Buffer sizes.
+   int endRCVBUF = 0;
+   optSize = sizeof(endRCVBUF);
+   if (0 != ::getsockopt(
+               m_iSocket, SOL_SOCKET, SO_RCVBUF, (void*)&endRCVBUF, &optSize))
+   {
+      endRCVBUF = -1;
+   }
+   int endSNDBUF = 0;
+   optSize = sizeof(endSNDBUF);
+   if (0 != ::getsockopt(
+               m_iSocket, SOL_SOCKET, SO_SNDBUF, (void*)&endSNDBUF, &optSize))
+   {
+      endSNDBUF = -1;
+   }
+   LOGC(kmlog.Debug,
+      log
+         << "SO_RCVBUF:"
+         << " startRCVBUF=" << startRCVBUF
+         << " m_mcfg.iUDPRcvBufSize=" << m_mcfg.iUDPRcvBufSize
+         << " endRCVBUF=" << endRCVBUF);
+   LOGC(kmlog.Debug,
+      log
+         << "SO_SNDBUF:"
+         << " startSNDBUF=" << startSNDBUF
+         << " m_mcfg.iUDPSndBufSize=" << m_mcfg.iUDPSndBufSize
+         << " endSNDBUF=" << endSNDBUF);
+
 
     if (m_mcfg.iIpTTL != -1)
     {

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -152,11 +152,7 @@ typedef int32_t SRTSOCKET;
 static const int32_t SRTGROUP_MASK = (1 << 30);
 
 #ifdef _WIN32
-   #ifndef __MINGW32__
-      typedef SOCKET SYSSOCKET;
-   #else
-      typedef int SYSSOCKET;
-   #endif
+   typedef SOCKET SYSSOCKET;
 #else
    typedef int SYSSOCKET;
 #endif


### PR DESCRIPTION
This resolves solaris unit tests failures caused by `srt::CChannel::setUDPSockOpt()` calling `setsockopt()` which can return failure when attempting to increase the SND|RCV buffers in excess of the system maximums. It seems that since Linux is the odd duck here, this should be the default implementation for all platforms?

This also makes sure that we dont try to reduce the size of the SND|RCV buffers as the default is >64k on Solaris and I think most BSD platforms. I assume reducing the size is not a good idea?