### PR TITLE
Fix build default configuration for GCC <4.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,11 @@ endif()
 
 # options
 option(CYGWIN_USE_POSIX "Should the POSIX API be used for cygwin. Ignored if the system isn't cygwin." OFF)
-option(ENABLE_CXX11 "Should the c++11 parts (srt-live-transmit) be enabled" ON)
+if (CMAKE_CXX_COMPILER_ID MATCHES "^GNU$" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.7)
+	option(ENABLE_CXX11 "Should the c++11 parts (srt-live-transmit) be enabled" OFF)
+else()
+	option(ENABLE_CXX11 "Should the c++11 parts (srt-live-transmit) be enabled" ON)
+endif()
 option(ENABLE_APPS "Should the Support Applications be Built?" ON)
 option(ENABLE_EXPERIMENTAL_BONDING "Should the EXPERIMENTAL bonding functionality be enabled?" OFF)
 option(ENABLE_TESTING "Should the Developer Test Applications be Built?" OFF)


### PR DESCRIPTION
This fixes default build configuration for `GCC<4.7`. This fixes default build configuration for `CentOS<7`, `Ubuntu<14`, and `Slackware<14`.

This changes sets the `ENABLE_CXX11` default to `OFF` when the compiler is `GCC<4.7`. `c++11` was introduced in `GCC-4.7.0`. This PR allows building of OpenSRT when running `cmake` without `-DENABLE_CXX11=OFF` on those platforms.