### PR TITLE
Adding AES GCM

### DIFF
--- a/haicrypt/hcrypt.c
+++ b/haicrypt/hcrypt.c
@@ -200,6 +200,9 @@ int HaiCrypt_ExtractConfig(HaiCrypt_Handle hhcSrc, HaiCrypt_Cfg* pcfg)
     if (ctx->mode == HCRYPT_CTX_MODE_AESGCM)
         pcfg->flags |= HAICRYPT_CFG_F_GCM;
 
+    if (ctx->mode == HCRYPT_CTX_MODE_AESGCM)
+        pcfg->flags |= HAICRYPT_CFG_F_GCM;
+
     /* Set this explicitly - this use of this library is SRT only. */
     pcfg->xport = HAICRYPT_XPT_SRT;
     pcfg->cryspr = crypto->cryspr;
@@ -236,7 +239,7 @@ int HaiCrypt_Clone(HaiCrypt_Handle hhcSrc, HaiCrypt_CryptoDir tx, HaiCrypt_Handl
 
     ASSERT(NULL != hhcSrc);
 
-    HCRYPT_LOG(LOG_INFO, "%s\n", "creating CLONED crypto context");
+    HCRYPT_LOG(LOG_INFO, "creating CLONED %s crypto context\n", (tx ? "tx" : "rx"));
 
     if (tx) {
         HaiCrypt_Cfg crypto_config;

--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -104,6 +104,8 @@ namespace srt_logging
 namespace srt
 {
 
+#define SRT_AUTHTAG_BYTELEN 16 // AEAD authentication tag len
+
 // Class CUDTException exposed for C++ API.
 // This is actually useless, unless you'd use a DIRECT C++ API,
 // however there's no such API so far. The current C++ API for UDT/SRT

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -871,6 +871,8 @@ void srt::CUDT::clearData()
     int udpsize = m_config.iMSS - CPacket::UDP_HDR_SIZE;
 
     m_iMaxSRTPayloadSize = udpsize - CPacket::HDR_SIZE;
+    //if (m_config.iCryptoMode != 0)
+    //    m_iMaxSRTPayloadSize -= SRT_AUTHTAG_BYTELEN;
 
     HLOGC(cnlog.Debug, log << CONID() << "clearData: PAYLOAD SIZE: " << m_iMaxSRTPayloadSize);
 
@@ -5478,6 +5480,7 @@ bool srt::CUDT::prepareConnectionObjects(const CHandShake &hs, HandshakeSide hsd
 
     try
     {
+        // TODO: Set auth tag size depending on the crypto mode.
         const int authtag = m_config.iCryptoMode == CSrtConfig::CIPHER_MODE_AES_GCM ? HAICRYPT_AUTHTAG_MAX : 0;
         m_pSndBuffer = new CSndBuffer(32, m_iMaxSRTPayloadSize, authtag);
         SRT_ASSERT(m_iISN != -1);

--- a/srtcore/packet.cpp
+++ b/srtcore/packet.cpp
@@ -151,11 +151,11 @@ modified by
 //   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 //
 //   Loss List Field Coding:
-//      For any consectutive lost seqeunce numbers that the differnece between
+//      For any consecutive lost sequence numbers that the difference between
 //      the last and first is more than 1, only record the first (a) and the
 //      the last (b) sequence numbers in the loss list field, and modify the
 //      the first bit of a to 1.
-//      For any single loss or consectutive loss less than 2 packets, use
+//      For any single loss or consecutive loss less than 2 packets, use
 //      the original sequence numbers in the field.
 
 #include "platform_sys.h"
@@ -174,7 +174,7 @@ using namespace srt_logging;
 
 namespace srt {
 
-// Set up the aliases in the constructure
+// Set up the aliases in the constructor
 CPacket::CPacket()
     : m_extra_pad()
     , m_data_owned(false)
@@ -340,7 +340,7 @@ void CPacket::pack(UDTMessageType pkttype, const int32_t* lparam, void* rparam, 
             m_nHeader[SRT_PH_MSGNO] = *lparam;
 
         // data ACK seq. no.
-        // optional: RTT (microsends), RTT variance (microseconds) advertised flow window size (packets), and estimated
+        // optional: RTT (microseconds), RTT variance (microseconds) advertised flow window size (packets), and estimated
         // link capacity (packets per second)
         m_PacketVector[PV_DATA].set(rparam, size);
 
@@ -552,7 +552,7 @@ void CPacket::setMsgCryptoFlags(EncryptionKeySpec spec)
 
 uint32_t CPacket::getMsgTimeStamp() const
 {
-    // SRT_DEBUG_TSBPD_WRAP may enable smaller timestamp for faster wraparoud handling tests
+    // SRT_DEBUG_TSBPD_WRAP may enable smaller timestamp for faster wraparound handling tests
     return (uint32_t)m_nHeader[SRT_PH_TIMESTAMP] & TIMESTAMP_MASK;
 }
 

--- a/test/filelist.maf
+++ b/test/filelist.maf
@@ -6,6 +6,7 @@ test_buffer_rcv.cpp
 test_common.cpp
 test_connection_timeout.cpp
 test_crypto.cpp
+test_crypto_conn.cpp
 test_cryspr.cpp
 test_enforced_encryption.cpp
 test_epoll.cpp

--- a/test/test_crypto.cpp
+++ b/test/test_crypto.cpp
@@ -33,6 +33,7 @@ namespace srt
         {
             CSrtConfig cfg;
 
+
             memset(&cfg.CryptoSecret, 0, sizeof(cfg.CryptoSecret));
             cfg.CryptoSecret.typ = HAICRYPT_SECTYP_PASSPHRASE;
             cfg.CryptoSecret.len = (m_pwd.size() <= (int)sizeof(cfg.CryptoSecret.str) ? m_pwd.size() : (int)sizeof(cfg.CryptoSecret.str));
@@ -52,6 +53,7 @@ namespace srt
             uint32_t kmout[72];
             size_t kmout_len = 72;
 
+
             std::array<uint32_t, 72> km_nworder;
             NtoHLA(km_nworder.data(), reinterpret_cast<const uint32_t*>(kmmsg), km_len);
             m_crypt.processSrtMsg_KMREQ(km_nworder.data(), km_len, 5, kmout, kmout_len);
@@ -65,7 +67,9 @@ namespace srt
 
         srt::CCryptoControl m_crypt;
         const std::string m_pwd = "abcdefghijk";
+ 
     };
+
 
 
     // Check that destroying the buffer also frees memory units.
@@ -88,6 +92,7 @@ namespace srt
 
         pkt.m_iSeqNo = seqno;
         pkt.m_iMsgNo = msgno | inorder | PacketBoundaryBits(PB_SOLO) | MSGNO_ENCKEYSPEC::wrap(kflg);;
+
         pkt.m_iTimeStamp = 356;
 
         std::iota(pkt.data(), pkt.data() + pld_size, '0');

--- a/test/test_crypto_conn.cpp
+++ b/test/test_crypto_conn.cpp
@@ -115,13 +115,13 @@ const TestCaseNonBlocking g_test_matrix_non_blocking[] =
     /*A.4 */ { {2,     2 }, {s_pwd_no,  s_pwd_b}, { SRT_SUCCESS, SRT_INVALID_SOCK,             0,  0,             {SRTS_BROKEN,       IGNORE_SRTS}, {SRT_KM_S_UNSECURED,        IGNORE_SRTS}}},
     /*A.5 */ { {2,     2 }, {s_pwd_no, s_pwd_no}, { SRT_SUCCESS,                0,             1,  SRT_EPOLL_IN,  {SRTS_CONNECTED, SRTS_CONNECTED}, {SRT_KM_S_UNSECURED, SRT_KM_S_UNSECURED}}},
 
-    /*B.1 */ { {2,     1 }, {s_pwd_a,   s_pwd_a}, { SRT_SUCCESS,                0,             1,  SRT_EPOLL_IN,  {SRTS_CONNECTED, SRTS_CONNECTED}, {SRT_KM_S_SECURED,     SRT_KM_S_SECURED}}},
-    /*B.2 */ { {2,     1 }, {s_pwd_a,   s_pwd_b}, { SRT_SUCCESS,                0,  IGNORE_EPOLL,  0,             {SRTS_CONNECTING,   SRTS_BROKEN}, {SRT_KM_S_BADSECRET, SRT_KM_S_BADSECRET}}},
-    /*B.3 */ { {2,     1 }, {s_pwd_a,  s_pwd_no}, { SRT_SUCCESS,                0,  IGNORE_EPOLL,  0,             {SRTS_CONNECTING,   SRTS_BROKEN}, {SRT_KM_S_UNSECURED, SRT_KM_S_UNSECURED}}},
-    /*B.4 */ { {2,     1 }, {s_pwd_no,  s_pwd_b}, { SRT_SUCCESS,                0,  IGNORE_EPOLL,  0,             {SRTS_CONNECTING,   SRTS_BROKEN}, {SRT_KM_S_UNSECURED,  SRT_KM_S_NOSECRET}}},
+    /*B.1 */ { {2,     1 }, {s_pwd_a,   s_pwd_a}, { SRT_SUCCESS, SRT_INVALID_SOCK,  IGNORE_EPOLL,  0,             {SRTS_CONNECTING,   SRTS_BROKEN}, {SRT_KM_S_UNSECURED, SRT_KM_S_UNSECURED}}},
+    /*B.2 */ { {2,     1 }, {s_pwd_a,   s_pwd_b}, { SRT_SUCCESS, SRT_INVALID_SOCK,  IGNORE_EPOLL,  0,             {SRTS_CONNECTING,   SRTS_BROKEN}, {SRT_KM_S_UNSECURED, SRT_KM_S_BADSECRET}}},
+    /*B.3 */ { {2,     1 }, {s_pwd_a,  s_pwd_no}, { SRT_SUCCESS, SRT_INVALID_SOCK,  IGNORE_EPOLL,  0,             {SRTS_CONNECTING,   SRTS_BROKEN}, {SRT_KM_S_UNSECURED, SRT_KM_S_UNSECURED}}},
+    /*B.4 */ { {2,     1 }, {s_pwd_no,  s_pwd_b}, { SRT_SUCCESS, SRT_INVALID_SOCK,  IGNORE_EPOLL,  0,             {SRTS_CONNECTING,   SRTS_BROKEN}, {SRT_KM_S_UNSECURED,  SRT_KM_S_NOSECRET}}},
     /*B.5 */ { {2,     1 }, {s_pwd_no, s_pwd_no}, { SRT_SUCCESS,                0,             1,  SRT_EPOLL_IN,  {SRTS_CONNECTED, SRTS_CONNECTED}, {SRT_KM_S_UNSECURED, SRT_KM_S_UNSECURED}}},
 
-    /*C.1 */ { {1,     2 }, {s_pwd_a,   s_pwd_a}, { SRT_SUCCESS,                0,             1,  SRT_EPOLL_IN,  {SRTS_CONNECTED, SRTS_CONNECTED}, {SRT_KM_S_SECURED,     SRT_KM_S_SECURED}}},
+    /*C.1 */ { {1,     2 }, {s_pwd_a,   s_pwd_a}, { SRT_SUCCESS, SRT_INVALID_SOCK,             0,  0,             {SRTS_BROKEN,       IGNORE_SRTS}, {SRT_KM_S_UNSECURED,        IGNORE_SRTS}}},
     /*C.2 */ { {1,     2 }, {s_pwd_a,   s_pwd_b}, { SRT_SUCCESS, SRT_INVALID_SOCK,             0,  0,             {SRTS_BROKEN,       IGNORE_SRTS}, {SRT_KM_S_UNSECURED,        IGNORE_SRTS}}},
     /*C.3 */ { {1,     2 }, {s_pwd_a,  s_pwd_no}, { SRT_SUCCESS, SRT_INVALID_SOCK,             0,  0,             {SRTS_BROKEN,       IGNORE_SRTS}, {SRT_KM_S_UNSECURED,        IGNORE_SRTS}}},
     /*C.4 */ { {1,     2 }, {s_pwd_no,  s_pwd_b}, { SRT_SUCCESS, SRT_INVALID_SOCK,             0,  0,             {SRTS_BROKEN,       IGNORE_SRTS}, {SRT_KM_S_UNSECURED,        IGNORE_SRTS}}},
@@ -149,7 +149,7 @@ const TestCaseBlocking g_test_matrix_blocking[] =
     /*C.2 */ { {1,    2  }, {s_pwd_a,   s_pwd_b}, { SRT_INVALID_SOCK,               -2, {SRTS_OPENED,                -1}, {SRT_KM_S_UNSECURED,                 -1}}},
     /*C.3 */ { {1,    2  }, {s_pwd_a,  s_pwd_no}, { SRT_INVALID_SOCK,               -2, {SRTS_OPENED,                -1}, {SRT_KM_S_UNSECURED,                 -1}}},
     /*C.4 */ { {1,    2  }, {s_pwd_no,  s_pwd_b}, { SRT_INVALID_SOCK,               -2, {SRTS_OPENED,                -1}, {SRT_KM_S_UNSECURED,                 -1}}},
-    /*C.5 */ { {1,    2  }, {s_pwd_no, s_pwd_no}, { SRT_INVALID_SOCK,                0, {SRTS_CONNECTED, SRTS_CONNECTED}, {SRT_KM_S_UNSECURED, SRT_KM_S_UNSECURED}}}
+    /*C.5 */ { {1,    2  }, {s_pwd_no, s_pwd_no}, { SRT_SUCCESS,                     0, {SRTS_CONNECTED, SRTS_CONNECTED}, {SRT_KM_S_UNSECURED, SRT_KM_S_UNSECURED}}}
 };
 
 } // namespace ciphermode
@@ -473,7 +473,7 @@ public:
             EXPECT_NE(num_bytes, SRT_ERROR);
             EXPECT_EQ(num_bytes, buff.size());
 
-            accept_io.get();
+            accept_io.wait();
         }
         else
         {
@@ -494,8 +494,11 @@ public:
             // srt_accept() has no timeout, so we have to close the socket and wait for the thread to exit.
             // Just give it some time and close the socket.
             std::this_thread::sleep_for(std::chrono::milliseconds(50));
-            ASSERT_NE(srt_close(m_listener_socket), SRT_ERROR);
-            accepted_future.wait();
+            std::cerr << "closing listener\n";
+            EXPECT_NE(srt_close(m_listener_socket), SRT_ERROR);
+            std::cerr << "Waiting accept thread.\n";
+            if (accepted_future.valid())
+                accepted_future.wait();
         }
     }
 

--- a/test/test_crypto_conn.cpp
+++ b/test/test_crypto_conn.cpp
@@ -1,0 +1,642 @@
+/*
+ * SRT - Secure, Reliable, Transport
+ * Copyright (c) 2018 Haivision Systems Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Written by:
+ *             Haivision Systems Inc.
+ */
+
+#include <gtest/gtest.h>
+#include <thread>
+#include <condition_variable> 
+#include <mutex>
+
+#include "srt.h"
+#include "sync.h"
+
+
+namespace ciphermode {
+
+enum PEER_TYPE
+{
+    PEER_CALLER = 0,
+    PEER_LISTENER = 1,
+    PEER_COUNT = 2,  // Number of peers
+};
+
+
+enum CHECK_SOCKET_TYPE
+{
+    CHECK_SOCKET_CALLER = 0,
+    CHECK_SOCKET_ACCEPTED = 1,
+    CHECK_SOCKET_COUNT = 2,  // Number of peers
+};
+
+
+enum TEST_CASE
+{
+    TEST_CASE_A_1 = 0,
+    TEST_CASE_A_2,
+    TEST_CASE_A_3,
+    TEST_CASE_A_4,
+    TEST_CASE_A_5,
+    TEST_CASE_B_1,
+    TEST_CASE_B_2,
+    TEST_CASE_B_3,
+    TEST_CASE_B_4,
+    TEST_CASE_B_5,
+    TEST_CASE_C_1,
+    TEST_CASE_C_2,
+    TEST_CASE_C_3,
+    TEST_CASE_C_4,
+    TEST_CASE_C_5,
+    TEST_CASE_D_1,
+    TEST_CASE_D_2,
+    TEST_CASE_D_3,
+    TEST_CASE_D_4,
+    TEST_CASE_D_5,
+};
+
+
+struct TestResultNonBlocking
+{
+    int     connect_ret;
+    int     accept_ret;
+    int     epoll_wait_ret;
+    int     epoll_event;
+    int     socket_state[CHECK_SOCKET_COUNT];
+    int     km_state[CHECK_SOCKET_COUNT];
+};
+
+
+struct TestResultBlocking
+{
+    int     connect_ret;
+    int     accept_ret;
+    int     socket_state[CHECK_SOCKET_COUNT];
+    int     km_state[CHECK_SOCKET_COUNT];
+};
+
+
+template<typename TResult>
+struct TestCase
+{
+    int                ciphermode[PEER_COUNT]; // 0 - AES-CTR, 1 - AES-GCM.
+    const std::string(&password)[PEER_COUNT];
+    TResult            expected_result;
+};
+
+typedef TestCase<TestResultNonBlocking>  TestCaseNonBlocking;
+typedef TestCase<TestResultBlocking>     TestCaseBlocking;
+
+
+
+static const std::string s_pwd_a("s!t@r#i$c^t");
+static const std::string s_pwd_b("s!t@r#i$c^tu");
+static const std::string s_pwd_no("");
+
+
+const int IGNORE_EPOLL = -2;
+const int IGNORE_SRTS = -1;
+
+const TestCaseNonBlocking g_test_matrix_non_blocking[] =
+{
+    // CIPHERMODE        |  Password           |                                | EPoll wait                       | socket_state                            |  KM State
+    // caller | listener |  caller  | listener |  connect_ret   accept_ret      |  ret         | event             | caller              accepted |  caller              listener
+    /*A.1 */ { {2,     2 }, {s_pwd_a,   s_pwd_a}, { SRT_SUCCESS,                0,             1,  SRT_EPOLL_IN,  {SRTS_CONNECTED, SRTS_CONNECTED}, {SRT_KM_S_SECURED,     SRT_KM_S_SECURED}}},
+    /*A.2 */ { {2,     2 }, {s_pwd_a,   s_pwd_b}, { SRT_SUCCESS, SRT_INVALID_SOCK,             0,  0,             {SRTS_BROKEN,       IGNORE_SRTS}, {SRT_KM_S_UNSECURED,        IGNORE_SRTS}}},
+    /*A.3 */ { {2,     2 }, {s_pwd_a,  s_pwd_no}, { SRT_SUCCESS, SRT_INVALID_SOCK,             0,  0,             {SRTS_BROKEN,       IGNORE_SRTS}, {SRT_KM_S_UNSECURED,        IGNORE_SRTS}}},
+    /*A.4 */ { {2,     2 }, {s_pwd_no,  s_pwd_b}, { SRT_SUCCESS, SRT_INVALID_SOCK,             0,  0,             {SRTS_BROKEN,       IGNORE_SRTS}, {SRT_KM_S_UNSECURED,        IGNORE_SRTS}}},
+    /*A.5 */ { {2,     2 }, {s_pwd_no, s_pwd_no}, { SRT_SUCCESS,                0,             1,  SRT_EPOLL_IN,  {SRTS_CONNECTED, SRTS_CONNECTED}, {SRT_KM_S_UNSECURED, SRT_KM_S_UNSECURED}}},
+
+    /*B.1 */ { {2,     1 }, {s_pwd_a,   s_pwd_a}, { SRT_SUCCESS,                0,             1,  SRT_EPOLL_IN,  {SRTS_CONNECTED, SRTS_CONNECTED}, {SRT_KM_S_SECURED,     SRT_KM_S_SECURED}}},
+    /*B.2 */ { {2,     1 }, {s_pwd_a,   s_pwd_b}, { SRT_SUCCESS,                0,  IGNORE_EPOLL,  0,             {SRTS_CONNECTING,   SRTS_BROKEN}, {SRT_KM_S_BADSECRET, SRT_KM_S_BADSECRET}}},
+    /*B.3 */ { {2,     1 }, {s_pwd_a,  s_pwd_no}, { SRT_SUCCESS,                0,  IGNORE_EPOLL,  0,             {SRTS_CONNECTING,   SRTS_BROKEN}, {SRT_KM_S_UNSECURED, SRT_KM_S_UNSECURED}}},
+    /*B.4 */ { {2,     1 }, {s_pwd_no,  s_pwd_b}, { SRT_SUCCESS,                0,  IGNORE_EPOLL,  0,             {SRTS_CONNECTING,   SRTS_BROKEN}, {SRT_KM_S_UNSECURED,  SRT_KM_S_NOSECRET}}},
+    /*B.5 */ { {2,     1 }, {s_pwd_no, s_pwd_no}, { SRT_SUCCESS,                0,             1,  SRT_EPOLL_IN,  {SRTS_CONNECTED, SRTS_CONNECTED}, {SRT_KM_S_UNSECURED, SRT_KM_S_UNSECURED}}},
+
+    /*C.1 */ { {1,     2 }, {s_pwd_a,   s_pwd_a}, { SRT_SUCCESS,                0,             1,  SRT_EPOLL_IN,  {SRTS_CONNECTED, SRTS_CONNECTED}, {SRT_KM_S_SECURED,     SRT_KM_S_SECURED}}},
+    /*C.2 */ { {1,     2 }, {s_pwd_a,   s_pwd_b}, { SRT_SUCCESS, SRT_INVALID_SOCK,             0,  0,             {SRTS_BROKEN,       IGNORE_SRTS}, {SRT_KM_S_UNSECURED,        IGNORE_SRTS}}},
+    /*C.3 */ { {1,     2 }, {s_pwd_a,  s_pwd_no}, { SRT_SUCCESS, SRT_INVALID_SOCK,             0,  0,             {SRTS_BROKEN,       IGNORE_SRTS}, {SRT_KM_S_UNSECURED,        IGNORE_SRTS}}},
+    /*C.4 */ { {1,     2 }, {s_pwd_no,  s_pwd_b}, { SRT_SUCCESS, SRT_INVALID_SOCK,             0,  0,             {SRTS_BROKEN,       IGNORE_SRTS}, {SRT_KM_S_UNSECURED,        IGNORE_SRTS}}},
+    /*C.5 */ { {1,     2 }, {s_pwd_no, s_pwd_no}, { SRT_SUCCESS,                0,             1,  SRT_EPOLL_IN,  {SRTS_CONNECTED, SRTS_CONNECTED}, {SRT_KM_S_UNSECURED, SRT_KM_S_UNSECURED}}}
+};
+
+
+const TestCaseBlocking g_test_matrix_blocking[] =
+{
+    // ENFORCEDENC       |  Password           |                      -2: don't check | socket_state                   |  KM State
+    // caller | listener |  caller  | listener |  connect_ret         accept_ret      | caller                accepted |  caller              listener
+    /*A.1 */ { {2,    2  }, {s_pwd_a,   s_pwd_a}, { SRT_SUCCESS,                     0, {SRTS_CONNECTED, SRTS_CONNECTED}, {SRT_KM_S_SECURED,     SRT_KM_S_SECURED}}},
+    /*A.2 */ { {2,    2  }, {s_pwd_a,   s_pwd_b}, { SRT_INVALID_SOCK, SRT_INVALID_SOCK, {SRTS_OPENED,                -1}, {SRT_KM_S_UNSECURED,                 -1}}},
+    /*A.3 */ { {2,    2  }, {s_pwd_a,  s_pwd_no}, { SRT_INVALID_SOCK, SRT_INVALID_SOCK, {SRTS_OPENED,                -1}, {SRT_KM_S_UNSECURED,                 -1}}},
+    /*A.4 */ { {2,    2  }, {s_pwd_no,  s_pwd_b}, { SRT_INVALID_SOCK, SRT_INVALID_SOCK, {SRTS_OPENED,                -1}, {SRT_KM_S_UNSECURED,                 -1}}},
+    /*A.5 */ { {2,    2  }, {s_pwd_no, s_pwd_no}, { SRT_SUCCESS,                     0, {SRTS_CONNECTED, SRTS_CONNECTED}, {SRT_KM_S_UNSECURED, SRT_KM_S_UNSECURED}}},
+
+    /*B.1 */ { {2,    1  }, {s_pwd_a,   s_pwd_a}, { SRT_INVALID_SOCK,               -2, {SRTS_OPENED,                -1}, {SRT_KM_S_UNSECURED, SRT_KM_S_UNSECURED}}},
+    /*B.2 */ { {2,    1  }, {s_pwd_a,   s_pwd_b}, { SRT_INVALID_SOCK,               -2, {SRTS_OPENED,                -1}, {SRT_KM_S_UNSECURED, SRT_KM_S_UNSECURED}}},
+    /*B.3 */ { {2,    1  }, {s_pwd_a,  s_pwd_no}, { SRT_INVALID_SOCK,               -2, {SRTS_OPENED,                -1}, {SRT_KM_S_UNSECURED, SRT_KM_S_UNSECURED}}},
+    /*B.4 */ { {2,    1  }, {s_pwd_no,  s_pwd_b}, { SRT_INVALID_SOCK,               -2, {SRTS_OPENED,                -1}, {SRT_KM_S_UNSECURED,  SRT_KM_S_NOSECRET}}},
+    /*B.5 */ { {2,    1  }, {s_pwd_no, s_pwd_no}, { SRT_SUCCESS,                     0, {SRTS_CONNECTED, SRTS_CONNECTED}, {SRT_KM_S_UNSECURED, SRT_KM_S_UNSECURED}}},
+
+    /*C.1 */ { {1,    2  }, {s_pwd_a,   s_pwd_a}, { SRT_INVALID_SOCK,               -2, {SRTS_OPENED,                -1}, {SRT_KM_S_UNSECURED,                 -1}}},
+    /*C.2 */ { {1,    2  }, {s_pwd_a,   s_pwd_b}, { SRT_INVALID_SOCK,               -2, {SRTS_OPENED,                -1}, {SRT_KM_S_UNSECURED,                 -1}}},
+    /*C.3 */ { {1,    2  }, {s_pwd_a,  s_pwd_no}, { SRT_INVALID_SOCK,               -2, {SRTS_OPENED,                -1}, {SRT_KM_S_UNSECURED,                 -1}}},
+    /*C.4 */ { {1,    2  }, {s_pwd_no,  s_pwd_b}, { SRT_INVALID_SOCK,               -2, {SRTS_OPENED,                -1}, {SRT_KM_S_UNSECURED,                 -1}}},
+    /*C.5 */ { {1,    2  }, {s_pwd_no, s_pwd_no}, { SRT_INVALID_SOCK,                0, {SRTS_CONNECTED, SRTS_CONNECTED}, {SRT_KM_S_UNSECURED, SRT_KM_S_UNSECURED}}}
+};
+
+} // namespace ciphermode
+
+using namespace ciphermode;
+
+class TestCipherMode
+    : public ::testing::Test
+{
+protected:
+    TestCipherMode()
+    {
+        // initialization code here
+    }
+
+    ~TestCipherMode()
+    {
+        // cleanup any pending stuff, but no exceptions allowed
+    }
+
+protected:
+
+    // SetUp() is run immediately before a test starts.
+    void SetUp()
+    {
+        ASSERT_EQ(srt_startup(), 0);
+
+        m_pollid = srt_epoll_create();
+        ASSERT_GE(m_pollid, 0);
+
+        m_caller_socket = srt_create_socket();
+        ASSERT_NE(m_caller_socket, SRT_INVALID_SOCK);
+
+        ASSERT_NE(srt_setsockflag(m_caller_socket, SRTO_SENDER, &s_yes, sizeof s_yes), SRT_ERROR);
+        ASSERT_NE(srt_setsockopt(m_caller_socket, 0, SRTO_TSBPDMODE, &s_yes, sizeof s_yes), SRT_ERROR);
+
+        m_listener_socket = srt_create_socket();
+        ASSERT_NE(m_listener_socket, SRT_INVALID_SOCK);
+
+        ASSERT_NE(srt_setsockflag(m_listener_socket, SRTO_SENDER, &s_no, sizeof s_no), SRT_ERROR);
+        ASSERT_NE(srt_setsockopt(m_listener_socket, 0, SRTO_TSBPDMODE, &s_yes, sizeof s_yes), SRT_ERROR);
+
+        // Will use this epoll to wait for srt_accept(...)
+        const int epoll_out = SRT_EPOLL_IN | SRT_EPOLL_ERR;
+        ASSERT_NE(srt_epoll_add_usock(m_pollid, m_listener_socket, &epoll_out), SRT_ERROR);
+    }
+
+    void TearDown()
+    {
+        // Code here will be called just after the test completes.
+        // OK to throw exceptions from here if needed.
+        ASSERT_NE(srt_close(m_caller_socket), SRT_ERROR);
+        ASSERT_NE(srt_close(m_listener_socket), SRT_ERROR);
+        srt_cleanup();
+    }
+
+
+public:
+    int SetCryptoMode(PEER_TYPE peer, int32_t value)
+    {
+        const SRTSOCKET& socket = peer == PEER_CALLER ? m_caller_socket : m_listener_socket;
+        return srt_setsockopt(socket, 0, SRTO_CRYPTOMODE, &value, sizeof value);
+    }
+
+
+    int32_t GetCryptoMode(PEER_TYPE peer_type)
+    {
+        const SRTSOCKET socket = peer_type == PEER_CALLER ? m_caller_socket : m_listener_socket;
+        int32_t optval;
+        int  optlen = sizeof optval;
+        EXPECT_EQ(srt_getsockopt(socket, 0, SRTO_CRYPTOMODE, (void*)&optval, &optlen), SRT_SUCCESS);
+        return optval;
+    }
+
+
+    int SetPassword(PEER_TYPE peer_type, const std::basic_string<char>& pwd)
+    {
+        const SRTSOCKET socket = peer_type == PEER_CALLER ? m_caller_socket : m_listener_socket;
+        return srt_setsockopt(socket, 0, SRTO_PASSPHRASE, pwd.c_str(), (int)pwd.size());
+    }
+
+
+    int GetKMState(SRTSOCKET socket)
+    {
+        int km_state = 0;
+        int opt_size = sizeof km_state;
+        EXPECT_EQ(srt_getsockopt(socket, 0, SRTO_KMSTATE, reinterpret_cast<void*>(&km_state), &opt_size), SRT_SUCCESS);
+
+        return km_state;
+    }
+
+
+    int GetSocetkOption(SRTSOCKET socket, SRT_SOCKOPT opt)
+    {
+        int val = 0;
+        int size = sizeof val;
+        EXPECT_EQ(srt_getsockopt(socket, 0, opt, reinterpret_cast<void*>(&val), &size), SRT_SUCCESS);
+
+        return val;
+    }
+
+
+    template<typename TResult>
+    int WaitOnEpoll(const TResult& expect);
+
+
+    template<typename TResult>
+    const TestCase<TResult>& GetTestMatrix(TEST_CASE test_case) const;
+
+    template<typename TResult>
+    void TestConnect(TEST_CASE test_case/*, bool is_blocking*/)
+    {
+        const bool is_blocking = std::is_same<TResult, TestResultBlocking>::value;
+        if (is_blocking)
+        {
+            ASSERT_NE(srt_setsockopt(m_caller_socket, 0, SRTO_RCVSYN, &s_yes, sizeof s_yes), SRT_ERROR);
+            ASSERT_NE(srt_setsockopt(m_caller_socket, 0, SRTO_SNDSYN, &s_yes, sizeof s_yes), SRT_ERROR);
+            ASSERT_NE(srt_setsockopt(m_listener_socket, 0, SRTO_RCVSYN, &s_yes, sizeof s_yes), SRT_ERROR);
+            ASSERT_NE(srt_setsockopt(m_listener_socket, 0, SRTO_SNDSYN, &s_yes, sizeof s_yes), SRT_ERROR);
+        }
+        else
+        {
+            ASSERT_NE(srt_setsockopt(m_caller_socket, 0, SRTO_RCVSYN, &s_no, sizeof s_no), SRT_ERROR); // non-blocking mode
+            ASSERT_NE(srt_setsockopt(m_caller_socket, 0, SRTO_SNDSYN, &s_no, sizeof s_no), SRT_ERROR); // non-blocking mode
+            ASSERT_NE(srt_setsockopt(m_listener_socket, 0, SRTO_RCVSYN, &s_no, sizeof s_no), SRT_ERROR); // non-blocking mode
+            ASSERT_NE(srt_setsockopt(m_listener_socket, 0, SRTO_SNDSYN, &s_no, sizeof s_no), SRT_ERROR); // non-blocking mode
+        }
+
+        // Prepare input state
+        const TestCase<TResult>& test = GetTestMatrix<TResult>(test_case);
+        ASSERT_EQ(SetCryptoMode(PEER_CALLER, test.ciphermode[PEER_CALLER]), SRT_SUCCESS);
+        ASSERT_EQ(SetCryptoMode(PEER_LISTENER, test.ciphermode[PEER_LISTENER]), SRT_SUCCESS);
+
+        ASSERT_EQ(SetPassword(PEER_CALLER, test.password[PEER_CALLER]), SRT_SUCCESS);
+        ASSERT_EQ(SetPassword(PEER_LISTENER, test.password[PEER_LISTENER]), SRT_SUCCESS);
+
+        const TResult& expect = test.expected_result;
+
+        // Start testing
+        srt::sync::atomic<bool> caller_done;
+        sockaddr_in sa;
+        memset(&sa, 0, sizeof sa);
+        sa.sin_family = AF_INET;
+        sa.sin_port = htons(5200);
+        ASSERT_EQ(inet_pton(AF_INET, "127.0.0.1", &sa.sin_addr), 1);
+        sockaddr* psa = (sockaddr*)&sa;
+        ASSERT_NE(srt_bind(m_listener_socket, psa, sizeof sa), SRT_ERROR);
+        ASSERT_NE(srt_listen(m_listener_socket, 4), SRT_ERROR);
+
+        auto accepting_thread = std::thread([&] {
+            const int epoll_event = WaitOnEpoll(expect);
+
+            // In a blocking mode we expect a socket returned from srt_accept() if the srt_connect succeeded.
+            // In a non-blocking mode we expect a socket returned from srt_accept() if the srt_connect succeeded,
+            // otherwise SRT_INVALID_SOCKET after the listening socket is closed.
+            sockaddr_in client_address;
+            int length = sizeof(sockaddr_in);
+            SRTSOCKET accepted_socket = -1;
+            if (epoll_event == SRT_EPOLL_IN)
+            {
+                accepted_socket = srt_accept(m_listener_socket, (sockaddr*)&client_address, &length);
+                std::cout << "ACCEPT: done, result=" << accepted_socket << std::endl;
+            }
+            else
+            {
+                std::cout << "ACCEPT: NOT done\n";
+            }
+
+            if (accepted_socket == SRT_INVALID_SOCK)
+            {
+                std::cerr << "[T] ACCEPT ERROR: " << srt_getlasterror_str() << std::endl;
+            }
+            else
+            {
+                std::cerr << "[T] ACCEPT SUCCEEDED: @" << accepted_socket << "\n";
+            }
+
+            EXPECT_NE(accepted_socket, 0);
+            if (expect.accept_ret == SRT_INVALID_SOCK)
+            {
+                EXPECT_EQ(accepted_socket, SRT_INVALID_SOCK);
+            }
+            else if (expect.accept_ret != -2)
+            {
+                EXPECT_NE(accepted_socket, SRT_INVALID_SOCK);
+            }
+
+            if (accepted_socket != SRT_INVALID_SOCK && expect.socket_state[CHECK_SOCKET_ACCEPTED] != IGNORE_SRTS)
+            {
+                if (m_is_tracing)
+                {
+                    std::cerr << "EARLY Socket state accepted: " << m_socket_state[srt_getsockstate(accepted_socket)]
+                        << " (expected: " << m_socket_state[expect.socket_state[CHECK_SOCKET_ACCEPTED]] << ")\n";
+                    std::cerr << "KM State accepted:     " << m_km_state[GetKMState(accepted_socket)] << '\n';
+                    std::cerr << "RCV KM State accepted:     " << m_km_state[GetSocetkOption(accepted_socket, SRTO_RCVKMSTATE)] << '\n';
+                    std::cerr << "SND KM State accepted:     " << m_km_state[GetSocetkOption(accepted_socket, SRTO_SNDKMSTATE)] << '\n';
+                }
+
+                // We have to wait some time for the socket to be able to process the HS response from the caller.
+                // In test cases B2 - B4 the socket is expected to change its state from CONNECTED to BROKEN
+                // due to KM mismatches
+                do
+                {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+                } while (!caller_done);
+
+                // Special case when the expected state is "broken": if so, tolerate every possible
+                // socket state, just NOT LESS than SRTS_BROKEN, and also don't read any flags on that socket.
+
+                if (expect.socket_state[CHECK_SOCKET_ACCEPTED] == SRTS_BROKEN)
+                {
+                    EXPECT_GE(srt_getsockstate(accepted_socket), SRTS_BROKEN);
+                }
+                else
+                {
+                    EXPECT_EQ(srt_getsockstate(accepted_socket), expect.socket_state[CHECK_SOCKET_ACCEPTED]);
+                    EXPECT_EQ(GetSocetkOption(accepted_socket, SRTO_SNDKMSTATE), expect.km_state[CHECK_SOCKET_ACCEPTED]);
+                }
+
+                if (m_is_tracing)
+                {
+                    const SRT_SOCKSTATUS status = srt_getsockstate(accepted_socket);
+                    std::cerr << "LATE Socket state accepted: " << m_socket_state[status]
+                        << " (expected: " << m_socket_state[expect.socket_state[CHECK_SOCKET_ACCEPTED]] << ")\n";
+                }
+
+                // TODO: receive message.
+                // TODO: send message.
+            }
+        });
+
+        const int connect_ret = srt_connect(m_caller_socket, psa, sizeof sa);
+        EXPECT_EQ(connect_ret, expect.connect_ret);
+
+        if (connect_ret == SRT_ERROR && connect_ret != expect.connect_ret)
+        {
+            const int errc = srt_getlasterror(NULL);
+            std::cerr << "UNEXPECTED! srt_connect returned error: "
+                << srt_getlasterror_str() << " (code " << errc
+                << ", reject reason " << ((errc == SRT_ECONNREJ) ? srt_rejectreason_str(srt_getrejectreason(m_caller_socket)) : "n/a")
+                << ").\n";
+        }
+
+        caller_done = true;
+
+        if (is_blocking == false)
+            accepting_thread.join();
+
+        if (m_is_tracing)
+        {
+            std::cerr << "Socket state caller:   " << m_socket_state[srt_getsockstate(m_caller_socket)] << "\n";
+            std::cerr << "Socket state listener: " << m_socket_state[srt_getsockstate(m_listener_socket)] << "\n";
+            std::cerr << "KM State caller:       " << m_km_state[GetKMState(m_caller_socket)] << '\n';
+            std::cerr << "RCV KM State caller:   " << m_km_state[GetSocetkOption(m_caller_socket, SRTO_RCVKMSTATE)] << '\n';
+            std::cerr << "SND KM State caller:   " << m_km_state[GetSocetkOption(m_caller_socket, SRTO_SNDKMSTATE)] << '\n';
+            std::cerr << "KM State listener:     " << m_km_state[GetKMState(m_listener_socket)] << '\n';
+            const int errc = srt_getlasterror(NULL);
+            if (connect_ret == SRT_ERROR && errc == SRT_ECONNREJ)
+            {
+                std::cerr << "Caller reject reason: " << srt_rejectreason_str(srt_getrejectreason(m_caller_socket)) << "\n";
+            }
+        }
+
+        // If a blocking call to srt_connect() returned error, then the state is not valid,
+        // but we still check it because we know what it should be. This way we may see potential changes in the core behavior.
+        if (is_blocking)
+        {
+            EXPECT_EQ(srt_getsockstate(m_caller_socket), expect.socket_state[CHECK_SOCKET_CALLER]);
+        }
+        // A caller socket, regardless of the mode, if it's not expected to be connected, check negatively.
+        if (expect.socket_state[CHECK_SOCKET_CALLER] == SRTS_CONNECTED)
+        {
+            EXPECT_EQ(srt_getsockstate(m_caller_socket), SRTS_CONNECTED);
+
+            // TODO: Send message.
+            // TODO: Receive message.
+        }
+        else
+        {
+            // If the socket is not expected to be connected (might be CONNECTING),
+            // then it is ok if it's CONNECTING or BROKEN.
+            EXPECT_NE(srt_getsockstate(m_caller_socket), SRTS_CONNECTED);
+        }
+
+        EXPECT_EQ(GetSocetkOption(m_caller_socket, SRTO_RCVKMSTATE), expect.km_state[CHECK_SOCKET_CALLER]);
+
+        EXPECT_EQ(srt_getsockstate(m_listener_socket), SRTS_LISTENING);
+        EXPECT_EQ(GetKMState(m_listener_socket), SRT_KM_S_UNSECURED);
+
+        if (is_blocking)
+        {
+            // srt_accept() has no timeout, so we have to close the socket and wait for the thread to exit.
+            // Just give it some time and close the socket.
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+            ASSERT_NE(srt_close(m_listener_socket), SRT_ERROR);
+            accepting_thread.join();
+        }
+    }
+
+
+private:
+    // put in any custom data members that you need
+
+    SRTSOCKET m_caller_socket = SRT_INVALID_SOCK;
+    SRTSOCKET m_listener_socket = SRT_INVALID_SOCK;
+
+    int       m_pollid = 0;
+
+    const bool s_yes = true;
+    const bool s_no = false;
+
+    const bool          m_is_tracing = true;
+    static const char* m_km_state[];
+    static const char* const* m_socket_state;
+};
+
+
+
+template<>
+int TestCipherMode::WaitOnEpoll<TestResultBlocking>(const TestResultBlocking&)
+{
+    return SRT_EPOLL_IN;
+}
+
+static std::ostream& PrintEpollEvent(std::ostream& os, int events, int et_events)
+{
+    using namespace std;
+
+    static pair<int, const char*> const namemap[] = {
+        make_pair(SRT_EPOLL_IN, "R"),
+        make_pair(SRT_EPOLL_OUT, "W"),
+        make_pair(SRT_EPOLL_ERR, "E"),
+        make_pair(SRT_EPOLL_UPDATE, "U")
+    };
+
+    int N = Size(namemap);
+
+    for (int i = 0; i < N; ++i)
+    {
+        if (events & namemap[i].first)
+        {
+            os << "[";
+            if (et_events & namemap[i].first)
+                os << "^";
+            os << namemap[i].second << "]";
+        }
+    }
+
+    return os;
+}
+
+template<>
+int TestCipherMode::WaitOnEpoll<TestResultNonBlocking>(const TestResultNonBlocking& expect)
+{
+    const int default_len = 3;
+    SRT_EPOLL_EVENT ready[default_len];
+    const int epoll_res = srt_epoll_uwait(m_pollid, ready, default_len, 500);
+    std::cerr << "Epoll wait result: " << epoll_res;
+    if (epoll_res > 0)
+    {
+        std::cerr << " FOUND: @" << ready[0].fd << " in ";
+        PrintEpollEvent(std::cerr, ready[0].events, 0);
+    }
+    else
+    {
+        std::cerr << " NOTHING READY";
+    }
+    std::cerr << std::endl;
+
+    // Expect: -2 means that 
+    if (expect.epoll_wait_ret != IGNORE_EPOLL)
+    {
+        EXPECT_EQ(epoll_res, expect.epoll_wait_ret);
+    }
+
+    if (epoll_res == SRT_ERROR)
+    {
+        std::cerr << "Epoll returned error: " << srt_getlasterror_str() << " (code " << srt_getlasterror(NULL) << ")\n";
+        return 0;
+    }
+
+    // We have exactly one socket here and we expect to return
+    // only this one, or nothing.
+    if (epoll_res != 0)
+    {
+        EXPECT_EQ(epoll_res, 1);
+        EXPECT_EQ(ready[0].fd, m_listener_socket);
+    }
+
+    return epoll_res == 0 ? 0 : int(ready[0].events);
+}
+
+
+template<>
+const TestCase<TestResultBlocking>& TestCipherMode::GetTestMatrix<TestResultBlocking>(TEST_CASE test_case) const
+{
+    return g_test_matrix_blocking[test_case];
+}
+
+template<>
+const TestCase<TestResultNonBlocking>& TestCipherMode::GetTestMatrix<TestResultNonBlocking>(TEST_CASE test_case) const
+{
+    return g_test_matrix_non_blocking[test_case];
+}
+
+
+
+const char* TestCipherMode::m_km_state[] = {
+    "SRT_KM_S_UNSECURED (0)",      //No encryption
+    "SRT_KM_S_SECURING  (1)",      //Stream encrypted, exchanging Keying Material
+    "SRT_KM_S_SECURED   (2)",      //Stream encrypted, keying Material exchanged, decrypting ok.
+    "SRT_KM_S_NOSECRET  (3)",      //Stream encrypted and no secret to decrypt Keying Material
+    "SRT_KM_S_BADSECRET (4)"       //Stream encrypted and wrong secret, cannot decrypt Keying Material        
+};
+
+
+static const char* const socket_state_array[] = {
+    "IGNORE_SRTS",
+    "SRTS_INVALID",
+    "SRTS_INIT",
+    "SRTS_OPENED",
+    "SRTS_LISTENING",
+    "SRTS_CONNECTING",
+    "SRTS_CONNECTED",
+    "SRTS_BROKEN",
+    "SRTS_CLOSING",
+    "SRTS_CLOSED",
+    "SRTS_NONEXIST"
+};
+
+// A trick that allows the array to be indexed by -1
+const char* const* TestCipherMode::m_socket_state = socket_state_array + 1;
+
+/**
+ * @fn TestEnforcedEncryption.SetGetDefault
+ * @brief The default value for the enforced encryption should be ON
+ */
+//TEST_F(TestCipherMode, SetGetDefault)
+//{
+//    EXPECT_EQ(GetEnforcedEncryption(PEER_CALLER), true);
+//    EXPECT_EQ(GetEnforcedEncryption(PEER_LISTENER), true);
+//
+//    EXPECT_EQ(SetEnforcedEncryption(PEER_CALLER, false), SRT_SUCCESS);
+//    EXPECT_EQ(SetEnforcedEncryption(PEER_LISTENER, false), SRT_SUCCESS);
+//
+//    EXPECT_EQ(GetEnforcedEncryption(PEER_CALLER), false);
+//    EXPECT_EQ(GetEnforcedEncryption(PEER_LISTENER), false);
+//}
+
+
+#define CREATE_TEST_CASE_BLOCKING(CASE_NUMBER, DESC) TEST_F(TestCipherMode, CASE_NUMBER##_Blocking_##DESC)\
+{\
+    TestConnect<TestResultBlocking>(TEST_##CASE_NUMBER);\
+}
+
+#define CREATE_TEST_CASE_NONBLOCKING(CASE_NUMBER, DESC) TEST_F(TestCipherMode, CASE_NUMBER##_NonBlocking_##DESC)\
+{\
+    TestConnect<TestResultNonBlocking>(TEST_##CASE_NUMBER);\
+}
+
+
+#define CREATE_TEST_CASES(CASE_NUMBER, DESC) \
+    CREATE_TEST_CASE_NONBLOCKING(CASE_NUMBER, DESC) \
+    CREATE_TEST_CASE_BLOCKING(CASE_NUMBER, DESC)
+
+#ifdef SRT_ENABLE_ENCRYPTION
+CREATE_TEST_CASES(CASE_A_1, Cipher_GCM_GCM_Pwd_Set_Set_Match)
+CREATE_TEST_CASES(CASE_A_2, Cipher_GCM_GCM_Pwd_Set_Set_Mismatch)
+CREATE_TEST_CASES(CASE_A_3, Cipher_GCM_GCM_Pwd_Set_None)
+CREATE_TEST_CASES(CASE_A_4, Cipher_GCM_GCM_Pwd_None_Set)
+#endif
+CREATE_TEST_CASES(CASE_A_5, Cipher_GCM_GCM_Pwd_None_None)
+
+#ifdef SRT_ENABLE_ENCRYPTION
+CREATE_TEST_CASES(CASE_B_1, Cipher_GCM_CTR_Pwd_Set_Set_Match)
+CREATE_TEST_CASES(CASE_B_2, Cipher_GCM_CTR_Pwd_Set_Set_Mismatch)
+CREATE_TEST_CASES(CASE_B_3, Cipher_GCM_CTR_Pwd_Set_None)
+CREATE_TEST_CASES(CASE_B_4, Cipher_GCM_CTR_Pwd_None_Set)
+#endif
+CREATE_TEST_CASES(CASE_B_5, Cipher_GCM_CTR_Pwd_None_None)
+
+#ifdef SRT_ENABLE_ENCRYPTION
+CREATE_TEST_CASES(CASE_C_1, Cipher_CTR_GCM_Pwd_Set_Set_Match)
+CREATE_TEST_CASES(CASE_C_2, Cipher_CTR_GCM_Pwd_Set_Set_Mismatch)
+CREATE_TEST_CASES(CASE_C_3, Cipher_CTR_GCM_Pwd_Set_None)
+CREATE_TEST_CASES(CASE_C_4, Cipher_CTR_GCM_Pwd_None_Set)
+#endif
+CREATE_TEST_CASES(CASE_C_5, Cipher_CTR_GCM_Pwd_None_None)
+
+
+
+


### PR DESCRIPTION
- [x] Added `bool CCryptoControl::isAESGCMSupported()` - a function to determine whether AES-GCM is supported or not. Can be used in HS and socket options.
- [ ] Added `SRT_REJ_CRYPTO`, `SRT_KM_S_BADCRYPTOMODE`. Update the docs.
- [ ] Should SRT side indicate in HS whether AES-GCM is supported? If yes - where?

- `crysprFallback_MsEncrypt`

### TODO

- [ ] `CUDT::m_iMaxSRTPayloadSize` consider auth tag.
- [ ] Store the encrypted packet in the SND buffer (extra bytes for tag).
- [ ] `hcryptCtx_Tx_Init(..)` default initializes `HCRYPT_CTX_MODE_AESGCM`. Instead should init based on the config.